### PR TITLE
Fix RegEx to filter by extension

### DIFF
--- a/replication_toolkit/tokenize-lang.sh
+++ b/replication_toolkit/tokenize-lang.sh
@@ -23,7 +23,7 @@ while read repo ; do
 
   echo Repo: $repo 1>&2
   git --git-dir="$gdir" ls-tree -r --name-only $BRANCH |
-  grep ".$EXTENSION\$" |
+  grep "\.$EXTENSION\$" |
   while read file ; do
     echo File: $repo:$file 1>&2
     git --git-dir="$gdir" show $BRANCH:"$file" |


### PR DESCRIPTION
The dot (".") needs to be escaped.
Otherwise files ending with the letters of the extension and any other single character in front of these letters will match.
Unintended behavior: `file.c` is matched but also files without an extension such as `filec`  